### PR TITLE
force reboot

### DIFF
--- a/deployment/puppet/nailgun/templates/cobbler/fence_ssh.erb
+++ b/deployment/puppet/nailgun/templates/cobbler/fence_ssh.erb
@@ -23,9 +23,7 @@ def set_power_status(conn, options):
     if options["-o"] == "off":
         try:
             #conn.sendline("/sbin/reboot")
-            # on dev environment where Nodes hosted as VM on KVM reboot command will failed to reboot after halting.
-            # so the installation process will not get start until manually force reboot nodes.
-            # the following signal wills force reboot nodes.
+            #force reboot
             conn.sendline("echo 1 >/proc/sys/kernel/sysrq ; echo b >/proc/sysrq-trigger")
             conn.log_expect(options, options["-c"], int(options["-g"]))
             time.sleep(2)

--- a/deployment/puppet/nailgun/templates/cobbler/fence_ssh.erb
+++ b/deployment/puppet/nailgun/templates/cobbler/fence_ssh.erb
@@ -22,7 +22,11 @@ def get_power_status(conn, options):
 def set_power_status(conn, options):
     if options["-o"] == "off":
         try:
-            conn.sendline("/sbin/reboot")
+            #conn.sendline("/sbin/reboot")
+            # on dev environment where Nodes hosted as VM on KVM reboot command will failed to reboot after halting.
+            # so the installation process will not get start until manually force reboot nodes.
+            # the following signal wills force reboot nodes.
+            conn.sendline("echo 1 >/proc/sys/kernel/sysrq ; echo b >/proc/sysrq-trigger")
             conn.log_expect(options, options["-c"], int(options["-g"]))
             time.sleep(2)
         except:


### PR DESCRIPTION
when working on development or test lab's and using Virtual Environment for test porpose, there are time when reboot commands faild to fully reboot VM's after halting...
// like ACPI shutdown problems
is such a cased Could Deployment phase will be hang and finally timeout.
on the other side, VMs which was planned to be used as Cloud Node will remain unaccessible unitl manually restart.

We use this change on fence_ssh module to force reboot Nodes instead on soft reboot.
this method is inuse on first stage of env deployment.
ex: https://access.redhat.com/solutions/46662